### PR TITLE
add subscriptions to Repo, add asyncio support

### DIFF
--- a/arroba/storage.py
+++ b/arroba/storage.py
@@ -16,6 +16,13 @@ CommitData = namedtuple('CommitData', [
   'blocks',  # BlockMap
   'prev',    # CID or None
 ])
+# commit record format is:
+# {
+#     'version': 2,
+#     'did': [repo],
+#     'prev': [CID],
+#     'data': [CID],
+# }
 
 
 class BlockMap(dict):

--- a/arroba/tests/testutil.py
+++ b/arroba/tests/testutil.py
@@ -26,7 +26,7 @@ import unittest.util
 unittest.util._MAX_LENGTH = 999999
 
 
-class TestCase(unittest.TestCase):
+class TestCase(unittest.IsolatedAsyncioTestCase):
     maxDiff = None
     key = None
 
@@ -51,9 +51,11 @@ class TestCase(unittest.TestCase):
 
     @staticmethod
     def random_keys_and_cids(num):
-        timestamps = random.choices(range(int(datetime(2020, 1, 1).timestamp()) * 1000,
-                                          int(datetime(2100, 1, 1).timestamp()) * 1000),
-                                    k=num)
+        timestamps = random.choices(
+            range(int(datetime(2020, 1, 1).timestamp()) * 1000,
+                  int(datetime(2100, 1, 1).timestamp()) * 1000),
+            k=num)
+
         cids = set()
         for cid in dag_cbor.random.rand_cid():
             cids.add(cid)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ datastore = [
     'google-cloud-ndb>=2.0',
 ]
 flask = [
-    'Flask>=2.0',
+    'Flask[async]>=2.0',
     'flask-sock',
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ git+https://github.com/snarfed/dag-json.git#egg=dag_json
 git+https://github.com/snarfed/carbox.git#egg=carbox
 git+https://github.com/snarfed/lexrpc.git#egg=lexrpc
 
+asgiref==3.7.2
 async-timeout==4.0.2
 attrs==23.1.0
 bases==0.2.1


### PR DESCRIPTION
...in preparation for the com.atproto.sync.subscribeRepos XRPC.

Note that this adds asyncio support but keeps Flask, which runs each asyncio HTTP request in its own event loop and its own worker, which blocks until it's done: https://flask.palletsprojects.com/en/2.3.x/async-await/#performance . Not ideal. Eventually we might want to switch to ASGI and eg Quartz + Uvicorn.

The other, more important issue is that this design for in memory subscriptions make requests stateful, or at least pinned to repos. All operations on a given repo, including subscriptions and new commits, must go to the same WSGI worker so that they can be routed to subscribers and delivered over their subscribeRepos websockets. Hrmph.